### PR TITLE
passing event as an argument to onItemSelect and onSimpleEnter

### DIFF
--- a/unbxdAutosuggest.js
+++ b/unbxdAutosuggest.js
@@ -459,7 +459,7 @@ var unbxdAutoSuggestFunction = function($,Handlebars,undefined){
 			} else {
 				if (typeof this.options.onSimpleEnter == "function" && (this.lastKeyPressCode == 10 || this.lastKeyPressCode == 13)){
 					this.lastKeyEvent.preventDefault();
-					self.options.onSimpleEnter.call(self);
+					self.options.onSimpleEnter.call(self,event);
 				}
 				
 				return false;
@@ -488,7 +488,7 @@ var unbxdAutoSuggestFunction = function($,Handlebars,undefined){
 			}});
 
 			if (typeof this.options.onItemSelect == "function"){
-				this.options.onItemSelect.call(this,data,this.currentResults[data.type][parseInt(data['index'])]._original);
+				this.options.onItemSelect.call(this,data,this.currentResults[data.type][parseInt(data['index'])]._original,event);
 			}
 		}
 		,addToAnalytics:function(type,obj){


### PR DESCRIPTION
Using event as an argument in functions onItmSelect() and onSimpleEnter() we can prevent the default definition and apply the custom one. 