### PR TITLE
universal and classical ga tracking

### DIFF
--- a/app.js
+++ b/app.js
@@ -42,7 +42,10 @@ var ractive = new Ractive({
 			siteName : 'demosite-u1407617955968'
 			,APIKey : '64a4a2592a648ac8415e13c561e44991'
 			,minChars : 2
-			,showCarts : false
+		  ,showCarts : false
+		  ,integrations: {
+		    'universal': true
+		  }
 			,template : "1column" // "2column"
 			,cartType : "separate"
 			// ,noResultConfigMsg: 'No Results were Found'

--- a/index.html
+++ b/index.html
@@ -56,6 +56,17 @@ body {
 	margin: 10px;
 }
 	</style>
+	<script>
+	  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+	  ga('create', 'UA-52135874-3', 'auto');
+	  ga('send', 'pageview');
+
+</script>
+
 </head>
 <body>
 	<div id="container" style="width: 100%;"></div>

--- a/unbxdAutosuggest.js
+++ b/unbxdAutosuggest.js
@@ -554,10 +554,9 @@ var unbxdAutoSuggestFunction = function($,Handlebars,undefined){
 		eventLabel = this.getEventLabel(obj),
 		value = 1;
 	    if(key){
-	      if(key && key === true){
-		key = '_gaq';
-	      }
-	      window[key].push(['_trackEvent', 'U_Autocomplete', eventAction, eventLabel, value, true])
+	      if(key === true) key = '_gaq';
+	      if(window[key])
+		window[key].push(['_trackEvent', 'U_Autocomplete', eventAction, eventLabel, value, true])
 	    }
 	  }
 	  ,trackuniversal: function(type, obj){
@@ -567,10 +566,9 @@ var unbxdAutoSuggestFunction = function($,Handlebars,undefined){
 		value = 1;
 
 	    if(key){
-	      if(key && key === true){
-		key = 'ga';
-	      }
-	      window[key]('send', 'event', 'U_Autocomplete', eventAction, eventLabel, value, {'nonInteraction': 1});
+	      if(key === true) key = 'ga';
+	      if(window[key])
+		window[key]('send', 'event', 'U_Autocomplete', eventAction, eventLabel, value, {'nonInteraction': 1});
 	    }
 	  }
 		,showResults: function () {

--- a/unbxdAutosuggest.js
+++ b/unbxdAutosuggest.js
@@ -570,7 +570,7 @@ var unbxdAutoSuggestFunction = function($,Handlebars,undefined){
 	      if(key && key === true){
 		key = 'ga';
 	      }
-	      window[key]('send', 'event', 'U_Autocomplete', eventAction, eventLabel, value, {'non_Interaction': 1});
+	      window[key]('send', 'event', 'U_Autocomplete', eventAction, eventLabel, value, {'nonInteraction': 1});
 	    }
 	  }
 		,showResults: function () {


### PR DESCRIPTION
The autosuggest config needs to add a key
called integrations containing a key-value
pair of `integration-name: 'global object'||true`
integration-name can be either _classical_ or _universal_