### PR TITLE
Changes for self serve and partial mobile view support on screen resize without refresh

### DIFF
--- a/unbxdAutosuggest.css
+++ b/unbxdAutosuggest.css
@@ -14,6 +14,7 @@
     border-bottom-left-radius: 3px;
     box-shadow: 0 0.5rem 1.5rem rgba(0,0,0,0.5);
     font-size: 13px;
+    display: table;
 }
 
 .unbxd-as-wrapper ul {
@@ -33,21 +34,25 @@
 }
 
 .unbxd-as-extra-left .unbxd-as-maincontent {
-    float: right;
+    /* float: right; */
+    display: table-cell;
 }
 
 .unbxd-as-extra-right .unbxd-as-maincontent {
-    float: left;
+    /* float: left; */
+    display: table-cell;
 }
 
 .unbxd-as-extra-left .unbxd-as-sidecontent {
-    float: left;
+    /* float: left; */
     border-right: 1px solid #dedede;
+    display: table-cell;
 }
 
 .unbxd-as-extra-right .unbxd-as-sidecontent {
-    float: right;
+    /* float: right; */
     border-left: 1px solid #dedede;
+    display: table-cell;
 }
 
 .unbxd-as-sidecontent+.unbxd-as-maincontent {

--- a/unbxdAutosuggest.js
+++ b/unbxdAutosuggest.js
@@ -898,7 +898,7 @@ var unbxdAutoSuggestFunction = function ($, Handlebars, params) {
 
 			if (this.options.platform == 'io') {
 				// Calculate total width of autosuggest relative to screen width
-				totalWidth = (this.options.sideContentOn && this.options.sideContentOn === 'left') ? (pos.left + posSelector.outerWidth()) : document.body.clientWidth - pos.left;
+				totalWidth = this.options.preferInputWidthTotalContent ? posSelector.outerWidth() : (this.options.sideContentOn && this.options.sideContentOn === 'left') ? (pos.left + posSelector.outerWidth()) : document.body.clientWidth - pos.left;
 				if (totalWidth > document.body.clientWidth) {
 					totalWidth = document.body.clientWidth;
 				}
@@ -2109,7 +2109,7 @@ var unbxdAutoSuggestFunction = function ($, Handlebars, params) {
 						}
 						sideHtml = sideHtml + '</ul>';
 						
-						var mainHtml = '<ul class="unbxd-as-maincontent unbxd-as-suggestions-overall">';
+						mainHtml = mainHtml + '<ul class="unbxd-as-maincontent unbxd-as-suggestions-overall">';
 						if (this.options.suggestionsHeader) {
 							mainHtml = mainHtml + '<li class="unbxd-as-header unbxd-as-suggestions-header">' + this.options.suggestionsHeader + '</li>';
 						}

--- a/unbxdAutosuggest.js
+++ b/unbxdAutosuggest.js
@@ -230,6 +230,7 @@ var unbxdAutoSuggestFunction = function ($, Handlebars, params) {
 			, sideContentOn: "right" //"left"
 			, template: "1column" // "2column"
 			, theme: "#ff8400"
+			, hideOnResize: false
 			, mainTpl: ['inFields', 'keywordSuggestions', 'topQueries', 'popularProducts', 'promotedSuggestions']
 			, sideTpl: []
 			, showCarts: true // will be used in default template of popular products
@@ -540,6 +541,13 @@ var unbxdAutoSuggestFunction = function ($, Handlebars, params) {
 				}
 
 			});
+
+			$(window).bind('resize', function() {
+				if (self.options.hideOnResize) {
+					self.hideResults();
+				}
+			});
+
 			$(document).bind("click.auto", function (e) {
 				if (e.target == self.input) {
 					self.log("clicked on input : focused");
@@ -909,24 +917,19 @@ var unbxdAutoSuggestFunction = function ($, Handlebars, params) {
 					totalWidth = (45 * totalWidth / 100);
 				}
 
-				if (this.options.isMobile) {
-					if (this.options.isMobile()) {
-						this.options.template = '1column';
-					}
-				} else if (isMobile.any()) {
-					this.options.template = '1column';
-				}
+				// if (this.options.isMobile && this.options.isMobile()) {
+				// 	this.options.template = '1column';
+				// } else if (isMobile.any()) {
+				// 	this.options.template = '1column';
+				// } 
 
 				// Calculate mainwidth based on 1 or 2 columns
-				if (this.options.template == '1column') {
+				if (this.options.template == '1column' || (this.options.isMobile && this.options.isMobile()) || isMobile.any()) {
 					mwidth = this.options.preferInputWidthMainContent ? posSelector.outerWidth() : (60 * totalWidth / 100);
 				} else {
-					if (this.options.preferInputWidthMainContent) {
-						mwidth = posSelector.outerWidth();
-					} else {
-						mwidth = this.options.mainWidthPercent ? (this.options.mainWidthPercent * totalWidth / 100) : (30 * totalWidth / 100)
-					}
-
+					/* Removing this as this breaks when template is 2 column but preferinputwidthmaincotnent is true for mobile, popular products won't appear ever.
+					To solve this, there is another config, preferInputWidthTotalContent, which includes mainwidth and sidewidth = width of input selector */
+					mwidth = this.options.mainWidthPercent ? (this.options.mainWidthPercent * totalWidth / 100) : (30 * totalWidth / 100);
 				}
 			}
 
@@ -2133,10 +2136,8 @@ var unbxdAutoSuggestFunction = function ($, Handlebars, params) {
 	
 				mainHtml = mainHtml + '</ul>';
 
-				if (this.options.isMobile) {
-					if (this.options.isMobile()) {
-						html = mobileHtml + mainHtml;
-					}
+				if (this.options.isMobile && this.options.isMobile()) {
+					html = mobileHtml + mainHtml;
 				} else if (isMobile.any()) {
 					html = mobileHtml + mainHtml;
 				} else if (this.options.sideContentOn === "right") {

--- a/unbxdAutosuggest.js
+++ b/unbxdAutosuggest.js
@@ -241,9 +241,10 @@ var unbxdAutoSuggestFunction = function ($, Handlebars, params) {
 			, onItemSelect: null
 			, noResultTpl: null
 			, trendingSearches: {
-				enabled: false,
+				enabled: true,
 				tpl: "{{{safestring highlighted}}}",
-				maxCount: 6
+				maxCount: 6,
+				preferInputWidthTrending: true
 			}
 			, inFields: {
 				count: 2
@@ -945,8 +946,10 @@ var unbxdAutoSuggestFunction = function ($, Handlebars, params) {
 				//for more info http://bugs.jquery.com/ticket/10855
 				, fpos = { top: pos.top + (isNaN(bt) ? 0 : (bt + bb)) + posSelector.innerHeight() + 'px', left: pos.left + "px" };
 
+			var trendingWidth = this.options.trendingSearches.preferInputWidthTrending ? posSelector.outerWidth() : fwidth;
 			this.$results.find("ul.unbxd-as-maincontent").css("width", fwidth + "px");
 			this.$results.find("ul.unbxd-as-maincontent").css("box-sizing", "border-box");
+			this.$results.find("ul.unbxd-as-maincontent.unbxd-as-trending").css("width", trendingWidth + "px");
 
 			if (this.scrollbarWidth == null) {
 				this.setScrollWidth();
@@ -1942,7 +1945,7 @@ var unbxdAutoSuggestFunction = function ($, Handlebars, params) {
 				+ '{{/if}}';
 		}
 		, prepareTrendingQueriesHTML: function () {
-			return '<ul class="unbxd-as-maincontent unbxd-as-suggestions-overall">'
+			return '<ul class="unbxd-as-maincontent unbxd-as-suggestions-overall unbxd-as-trending">'
 				+ (this.options.trendingSearches.header ? '<li class="unbxd-as-header">' + this.options.trendingSearches.header + '</li>' : '')
 				+ '{{#each data1}}'
 				+ '<li class="unbxd-as-keysuggestion" data-value="{{autosuggest}}" data-index="{{@index}}" data-type="{{type}}"  data-source="{{source}}">'
@@ -2140,6 +2143,8 @@ var unbxdAutoSuggestFunction = function ($, Handlebars, params) {
 					html = mobileHtml + mainHtml;
 				} else if (isMobile.any()) {
 					html = mobileHtml + mainHtml;
+				} else if (this.options.template === "1column") {
+					html = html + mainHtml + '</ul>';
 				} else if (this.options.sideContentOn === "right") {
 					html = mainHtml + sideHtml;
 				} else {

--- a/unbxdAutosuggest.js
+++ b/unbxdAutosuggest.js
@@ -923,12 +923,6 @@ var unbxdAutoSuggestFunction = function ($, Handlebars, params) {
 					totalWidth = (45 * totalWidth / 100);
 				}
 
-				// if (this.options.isMobile && this.options.isMobile()) {
-				// 	this.options.template = '1column';
-				// } else if (isMobile.any()) {
-				// 	this.options.template = '1column';
-				// } 
-
 				// Calculate mainwidth based on 1 or 2 columns
 				if (this.options.template == '1column' || (this.options.isMobile && this.options.isMobile()) || isMobile.any()) {
 					mwidth = this.options.preferInputWidthMainContent ? posSelector.outerWidth() : (60 * totalWidth / 100);

--- a/unbxdAutosuggest.js
+++ b/unbxdAutosuggest.js
@@ -1617,8 +1617,6 @@ var unbxdAutoSuggestFunction = function ($, Handlebars, params) {
 				, _original: doc
 			};
 
-
-
 			if (this.options.popularProducts.name) {
 				o.autosuggest = doc[this.options.nameFunctionOrKey] ? doc[this.options.nameFunctionOrKey] : doc[this.options.popularProducts.title] ? doc[this.options.popularProducts.title] : '';
 			} else {
@@ -2012,7 +2010,8 @@ var unbxdAutoSuggestFunction = function ($, Handlebars, params) {
 		, prepareHTML: function () {
 			var html = '<ul class="unbxd-as-maincontent unbxd-as-suggestions-overall">';
 			var mobileHtml = '<ul class="unbxd-as-maincontent unbxd-as-suggestions-overall unbxd-as-mobile-view">';
-
+			var sideHtml = '';
+			var mainHtml = '';
 			if (this.options.isMobile) {
 				if (this.options.isMobile()) {
 					html = mobileHtml;
@@ -2026,7 +2025,7 @@ var unbxdAutoSuggestFunction = function ($, Handlebars, params) {
 				sidelen = 0;
 			if (this.options.suggestionsHeader && (self.currentResults['IN_FIELD'].length || self.currentResults['KEYWORD_SUGGESTION'].length
 				|| self.currentResults['TOP_SEARCH_QUERIES'].length)) {
-				html = html + '<li class="unbxd-as-header unbxd-as-suggestions-header">' + this.options.suggestionsHeader + '</li>';
+					mainHtml = mainHtml + '<li class="unbxd-as-header unbxd-as-suggestions-header">' + this.options.suggestionsHeader + '</li>';
 			}
 
 			if (!self.currentResults['IN_FIELD'].length && !self.currentResults['KEYWORD_SUGGESTION'].length
@@ -2092,24 +2091,27 @@ var unbxdAutoSuggestFunction = function ($, Handlebars, params) {
 				}
 				else {
 					if (sidelen != 0) {
+						
 						if (this.options.popularProducts.viewMore && this.options.popularProducts.viewMore.enabled) {
-							html = '<ul class="unbxd-as-sidecontent unbxd-as-view-more">';
+							sideHtml = '<ul class="unbxd-as-sidecontent unbxd-as-view-more">';
 						} else {
-							html = '<ul class="unbxd-as-sidecontent">';
+							sideHtml = '<ul class="unbxd-as-sidecontent">';
 						}
 						this.options.sideTpl.forEach(function (key) {
 							if (self.options.sortByLength && (key == 'topQueries' || key == 'keywordSuggestions')) {
 								return;
 							}
 							key = 'prepare' + key + 'HTML';
-							html = html + self[key]();
+							sideHtml = sideHtml + self[key]();
 						});
 						if (this.options.popularProducts.viewMore && this.options.popularProducts.viewMore.enabled) {
-							html = html + this.options.popularProducts.viewMore.tpl
+							sideHtml = sideHtml + this.options.popularProducts.viewMore.tpl
 						}
-						html = html + '</ul><ul class="unbxd-as-maincontent unbxd-as-suggestions-overall">';
+						sideHtml = sideHtml + '</ul>';
+						
+						var mainHtml = '<ul class="unbxd-as-maincontent unbxd-as-suggestions-overall">';
 						if (this.options.suggestionsHeader) {
-							html = html + '<li class="unbxd-as-header unbxd-as-suggestions-header">' + this.options.suggestionsHeader + '</li>';
+							mainHtml = mainHtml + '<li class="unbxd-as-header unbxd-as-suggestions-header">' + this.options.suggestionsHeader + '</li>';
 						}
 					}
 				}
@@ -2126,15 +2128,21 @@ var unbxdAutoSuggestFunction = function ($, Handlebars, params) {
 					return;
 				}
 				key = 'prepare' + key + 'HTML';
-				html = html + self[key]();
+				mainHtml = mainHtml + self[key]();
 			});
 
 			if (this.options.sortByLength) {
-				html = html + self['prepareSortedSuggestionsHTML']();
+				mainHtml = mainHtml + self['prepareSortedSuggestionsHTML']();
 			}
 
-			html = html + '</ul>';
-
+			mainHtml = mainHtml + '</ul>';
+			
+			if (this.options.sideContentOn === "right") {
+				html = mainHtml + sideHtml;
+			} else {
+				html = sideHtml + mainHtml;
+			}
+			
 			var cmpld = Handlebars.compile(html);
 			this.log("prepraing html :-> template : " + this.options.template + " ,carts : " + this.options.showCarts + " ,cartType : " + this.options.cartType);
 			this.log("html data : ", this.currentResults);

--- a/unbxdAutosuggest.js
+++ b/unbxdAutosuggest.js
@@ -909,6 +909,13 @@ var unbxdAutoSuggestFunction = function ($, Handlebars, params) {
 					totalWidth = (45 * totalWidth / 100);
 				}
 
+				if (this.options.isMobile) {
+					if (this.options.isMobile()) {
+						this.options.template = '1column';
+					}
+				} else if (isMobile.any()) {
+					this.options.template = '1column';
+				}
 
 				// Calculate mainwidth based on 1 or 2 columns
 				if (this.options.template == '1column') {
@@ -2013,13 +2020,6 @@ var unbxdAutoSuggestFunction = function ($, Handlebars, params) {
 			var sideHtml = '';
 			var mainHtml = '';
 			var noResults = false;
-			if (this.options.isMobile) {
-				if (this.options.isMobile()) {
-					html = mobileHtml;
-				}
-			} else if (isMobile.any()) {
-				html = mobileHtml;
-			}
 
 			var self = this,
 				mainlen = 0,
@@ -2064,14 +2064,6 @@ var unbxdAutoSuggestFunction = function ($, Handlebars, params) {
 					key = "KEYWORD_SUGGESTION";
 				sidelen = sidelen + self.currentResults[key].length;
 			});
-
-			if (this.options.isMobile) {
-				if (this.options.isMobile()) {
-					this.options.template = '1column';
-				}
-			} else if (isMobile.any()) {
-				this.options.template = '1column';
-			}
 
 			if (this.options.template === '2column' && !this.options.sideTpl.length && !this.options.mainTpl) {
 				this.options.sideTpl = ['keywordSuggestions', 'topQueries'];
@@ -2141,7 +2133,13 @@ var unbxdAutoSuggestFunction = function ($, Handlebars, params) {
 	
 				mainHtml = mainHtml + '</ul>';
 
-				if (this.options.sideContentOn === "right") {
+				if (this.options.isMobile) {
+					if (this.options.isMobile()) {
+						html = mobileHtml + mainHtml;
+					}
+				} else if (isMobile.any()) {
+					html = mobileHtml + mainHtml;
+				} else if (this.options.sideContentOn === "right") {
 					html = mainHtml + sideHtml;
 				} else {
 					html = sideHtml + mainHtml;

--- a/unbxdAutosuggest.js
+++ b/unbxdAutosuggest.js
@@ -454,7 +454,7 @@ var unbxdAutoSuggestFunction = function ($, Handlebars, params) {
 			// Render trending Search
 			if (this.options.trendingSearches.enabled) {
 				this.trendingQueries = [];
-				var trendingUrl = "https://search.unbxd.io/" + this.options.APIKey + "/" + this.options.siteName + "/autosuggest?trending-queries=true&q=*";
+				var trendingUrl = (this.options.searchEndPoint ? this.options.searchEndPoint + "/" : "https://search.unbxd.io/") + this.options.APIKey + "/" + this.options.siteName + "/autosuggest?trending-queries=true&q=*";
 				var that = this;
 				$.ajax({
 					url: trendingUrl,
@@ -554,9 +554,14 @@ var unbxdAutoSuggestFunction = function ($, Handlebars, params) {
 					self.log("clicked on input : focused");
 					self.hasFocus = true;
 					if (self.previous === self.$input.val())
-
-						self.showResults();
-
+						if (self.$results.find(".unbxd-as-trending").length) {
+							self.showResults();
+						} else if (self.$results.find(".unbxd-as-maincontent").length || self.$results.find(".unbxd-as-sidecontent").length) {
+							self.$results.html(self.prepareHTML());
+							self.showResults();
+						} else {
+							self.showResults();
+						}
 				} else if (e.target == self.$results[0]) {
 					self.log("clicked on results block : selecting")
 					self.hasFocus = false;


### PR DESCRIPTION
1. Height of both main content and side content should be equal, to apply css changes like background color, border radius, etc. Floats don't allow that hence using display table and display table cell.
2. Based on config, allow user to keep total width of autosuggest equal to the width of the searchbar.
3. Avoid unnecessary html computation if there are no results found or partial results found, and modify html accordingly.
4. Add mobile html changes too.
5. Hide autosuggest on screen resize based on user config, as resize makes the ui messy.