### PR TITLE
fix(autosuggest): hide autosuggest on window popstate.

### DIFF
--- a/unbxdAutosuggest.js
+++ b/unbxdAutosuggest.js
@@ -586,7 +586,7 @@ var unbxdAutoSuggestFunction = function ($, Handlebars, params) {
 			/** For single page applications, on browser back, the autosuggest doesn't remove */
 			window.addEventListener('popstate', function (event) {
 				if (self.options.removeOnBackButton) {
-					$('.unbxd-as-wrapper').remove();
+					$('.unbxd-as-wrapper').hide();
 				}
 			});
 


### PR DESCRIPTION
hide the autosuggest container instead of removing it on page navigation.